### PR TITLE
Fix vendor lookup concatenation

### DIFF
--- a/server/simon/03/index.php
+++ b/server/simon/03/index.php
@@ -55,7 +55,7 @@ if (IS_GET AND preg_match('~/network/.+/device/.+/info~', URI)) {
 	$result['mac_formated'] 			= mac_format($mac);
 	if (!empty($data1)) {
 		$result['status'] 				= $data1['status'];
-		$result['vendor'] 				= @file_get_contents('http://api.macvendors.com/'+urlencode($mac));
+		$result['vendor'] 				= @file_get_contents('http://api.macvendors.com/' . urlencode($mac));
 		$result['last_seen_seconds'] 	= time() - strtotime($data1['datetime']);
 		$result['last_seen_timestamp']	= strtotime($data1['datetime']);
 		$result['last_seen_datetime'] 	= $data1['datetime'];


### PR DESCRIPTION
## Summary
- correct string concatenation for mac vendor lookup URL

## Testing
- `php -l server/simon/03/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d43246c4832d8f44ee3b0d16e468