### PR TITLE
Fix target typo

### DIFF
--- a/server/simon/tests/test_posts.php
+++ b/server/simon/tests/test_posts.php
@@ -39,7 +39,7 @@
 </head>
 <body style="height:100%">
 	<div id="left" style="float: left; width:50%; display:inline-block;">
-		<form action="test_posts.php" method="post" id="tests" arget="_blank">
+		<form action="test_posts.php" method="post" id="tests" target="_blank">
 			<input type="text" id="url" value="./../api/store/mac"/><br />
 			<textarea id="body" rows="10" cols="50" wrap="off">{}</textarea><br />
 			<input type="submit" name="submit"/>


### PR DESCRIPTION
## Summary
- fix typo in test_posts.php to correctly target links

## Testing
- `grep -n "arget" -n server/simon/tests/test_posts.php`


------
https://chatgpt.com/codex/tasks/task_e_6866d53d3bb8832d839272d1e7b583e0