### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Slightliy similar to  https://github.com/raumzeitlabor/raumzeitstatus but with a less complicated hardware setup and stats about single (Wifi) LAN users. 
+Slightly similar to  https://github.com/raumzeitlabor/raumzeitstatus but with a less complicated hardware setup and stats about single (Wifi) LAN users.
 
 [List of technical ressources](resources.md) related to this project.
 


### PR DESCRIPTION
## Summary
- fix typo in README line 1

## Testing
- `php -l server/simon/03/index.php` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d43388a0832da754adb0468bfe75