### PR TITLE
Add architecture overview diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Dienste.
 - PHP‑Server mit MySQL‑Datenbank
 - Optional: SD‑Karte für Logfiles, PHP‑Microframework "klein"
 
+### Architektur
+
+Die folgenden Komponenten arbeiten zusammen, um die Nutzungsstatistiken im LAN
+zu erfassen. Die Skizze zeigt die wichtigsten Module und verwendeten
+Technologien.
+
+![Architekturübersicht](architecture.svg)
+
 ### Struktur
 
 - `autarc_lan_user_stats/` – eigentlicher Arduino‑Code samt Default‑Konfig

--- a/architecture.svg
+++ b/architecture.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="300" viewBox="0 0 600 300">
+  <style>
+    rect { fill:#f0f0f0; stroke:#333; stroke-width:1.5; }
+    text { font-family: Arial, sans-serif; font-size: 14px; }
+    line { stroke:#333; stroke-width:1.5; marker-end:url(#arrow); }
+  </style>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#333" />
+    </marker>
+  </defs>
+  <!-- Arduino box -->
+  <rect x="20" y="120" width="130" height="60" rx="5" />
+  <text x="85" y="145" text-anchor="middle">Arduino</text>
+  <text x="85" y="165" text-anchor="middle">Ethernet/WLAN</text>
+
+  <!-- PHP server box -->
+  <rect x="220" y="40" width="160" height="60" rx="5" />
+  <text x="300" y="65" text-anchor="middle">PHP Server</text>
+
+  <!-- MySQL box -->
+  <rect x="220" y="200" width="160" height="60" rx="5" />
+  <text x="300" y="225" text-anchor="middle">MySQL DB</text>
+
+  <!-- Web Client box -->
+  <rect x="440" y="120" width="130" height="60" rx="5" />
+  <text x="505" y="145" text-anchor="middle">Web Client</text>
+  <text x="505" y="165" text-anchor="middle">HTML/JS</text>
+
+  <!-- Connections -->
+  <line x1="150" y1="150" x2="220" y2="70" />
+  <line x1="300" y1="100" x2="300" y2="200" />
+  <line x1="380" y1="70" x2="440" y2="150" />
+  <line x1="440" y1="150" x2="380" y2="70" />
+</svg>


### PR DESCRIPTION
## Summary
- add a basic SVG showing architecture, modules and technologies
- document the architecture in the README with a new section

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867e1602af4832d9ccd05d3972e3fe3